### PR TITLE
update path to sslyze release 0.11.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 FROM debian:jessie
 MAINTAINER Alexander Turcic "alex@zeitgeist.se"
 
-ENV RELEASE_URL https://github.com/nabla-c0d3/sslyze/releases/download/release-0.11/sslyze-0_11-linux64.zip
+ENV RELEASE_URL https://github.com/nabla-c0d3/sslyze/releases/download/0.11.0/sslyze-0_11-linux64.zip
 ENV RELEASE_DIR /sslyze-0_11-linux64/sslyze
 
 # Compile sslyze


### PR DESCRIPTION
The path to the sslyze releases seems to have changed at some point.

The RELEASE_URL has been update to reflect that.